### PR TITLE
Add member self-service portal backed by CiviCRM API

### DIFF
--- a/lib/bacds/Scheduler.pm
+++ b/lib/bacds/Scheduler.pm
@@ -56,6 +56,7 @@ use bacds::Scheduler::Model::SeriesLister;
 use bacds::Scheduler::Model::Talent;
 use bacds::Scheduler::Model::Team;
 use bacds::Scheduler::Model::Style;
+use bacds::Scheduler::Model::MemberPortal;
 use bacds::Scheduler::Model::Venue;
 use bacds::Scheduler::Util::Cookie qw/LoginMethod LoginSession GoogleToken/;
 use bacds::Scheduler::Util::Db qw/get_dbh/;
@@ -1773,5 +1774,128 @@ sub ssi_uri_for {
     # extra ${} from Dancer2's uri_for, w/ever
     return ${ $uri->canonical };
 }
+
+=head2 GET /member
+
+Shows the email-entry form for the member self-service portal.
+
+=cut
+
+get '/unearth/member' => sub {
+    template 'member/request' => {
+        page_title => 'Manage Your BACDS Info',
+        season     => get_season(),
+    }, { layout => 'unearth-page-wrapper' };
+};
+
+=head2 POST /member/request-link
+
+Looks up the submitted email in CiviCRM and, if a contact is found, sends
+a magic link email via CiviCRM. Always redirects to the same confirmation
+page regardless of whether the email was recognised (prevents enumeration).
+
+=cut
+
+post '/unearth/member/request-link' => sub {
+    my $email = body_parameters->get('email') // '';
+    $email =~ s/^\s+|\s+$//g;
+
+    if (!$email || $email !~ /\@/) {
+        return template 'member/request' => {
+            page_title => 'Manage Your BACDS Info',
+            season     => get_season(),
+            error      => 'Please enter a valid email address.',
+            email      => $email,
+        }, { layout => 'unearth-page-wrapper' };
+    }
+
+    my $base_url = request->uri_base;
+    eval {
+        bacds::Scheduler::Model::MemberPortal->request_link(
+            $email, get_dbh(), $base_url,
+        );
+    };
+    if ($@) {
+        warn "MemberPortal request_link error for $email: $@";
+        # Don't expose internal errors to the user; fall through to the
+        # same confirmation page so as not to leak information.
+    }
+
+    template 'member/request_sent' => {
+        page_title => 'Check Your Email',
+        season     => get_season(),
+    }, { layout => 'unearth-page-wrapper' };
+};
+
+=head2 GET /member/portal?token=XXX
+
+Validates the magic link token and shows the pre-filled contact edit form.
+
+=cut
+
+get '/unearth/member/portal' => sub {
+    my $token = query_parameters->get('token') // '';
+
+    my ($contact, $error);
+    eval {
+        $contact = bacds::Scheduler::Model::MemberPortal->get_contact_for_portal(
+            $token, get_dbh(),
+        );
+    };
+    $error = $@ if $@;
+
+    template 'member/portal' => {
+        page_title => 'Your BACDS Info',
+        season     => get_season(),
+        token      => $token,
+        contact    => $contact,
+        error      => $error,
+    }, { layout => 'unearth-page-wrapper' };
+};
+
+=head2 POST /member/portal?token=XXX
+
+Re-validates the token, saves the submitted contact data to CiviCRM, and
+marks the token as used.
+
+=cut
+
+post '/unearth/member/portal' => sub {
+    my $token = body_parameters->get('token') // '';
+
+    my %form_data = map {
+        $_ => scalar(body_parameters->get($_))
+    } qw(first_name middle_name last_name nick_name
+         phone street_address city state postal_code country);
+
+    my $error;
+    eval {
+        bacds::Scheduler::Model::MemberPortal->save_contact(
+            $token, \%form_data, get_dbh(),
+        );
+    };
+    $error = $@ if $@;
+
+    if ($error) {
+        my ($contact);
+        eval {
+            $contact = bacds::Scheduler::Model::MemberPortal->get_contact_for_portal(
+                $token, get_dbh(),
+            );
+        };
+        return template 'member/portal' => {
+            page_title => 'Your BACDS Info',
+            season     => get_season(),
+            token      => $token,
+            contact    => $contact // \%form_data,
+            error      => $error,
+        }, { layout => 'unearth-page-wrapper' };
+    }
+
+    template 'member/portal_success' => {
+        page_title => 'Changes Saved',
+        season     => get_season(),
+    }, { layout => 'unearth-page-wrapper' };
+};
 
 true;

--- a/lib/bacds/Scheduler/CiviCRM.pm
+++ b/lib/bacds/Scheduler/CiviCRM.pm
@@ -20,6 +20,29 @@ Data operations use APIv4 (POST /civicrm/ajax/api4/{Entity}/{Action}).
 Email sending uses APIv3 MessageTemplate.send (POST /civicrm/ajax/rest),
 which is not available in APIv4.
 
+  Member browser          dance-scheduler (bacds.org)       CiviCRM (bacds.civicrm.org)
+        |                          |                                  |
+        |-- GET /member ---------->|                                  |
+        |<- email form ------------|                                  |
+        |                          |                                  |
+        |-- POST /member/request ->|-- Email.get (find by email) ---->|
+        |                          |<- contact_id -------------------|
+        |                          | generate token, store in DB      |
+        |                          |-- MessageTemplate.send ---------->|
+        |                          |   (contact_id, tplParams:{url})  |-- sends email -->member
+        |<- "check your inbox" ----|                                  |
+        |                          |                                  |
+        |-- GET /member/portal ---->|                                  |
+        |   ?token=XXX             | validate token                   |
+        |                          |-- Contact.get ------------------>|
+        |                          |   Address.get, Phone.get         |
+        |<- pre-filled form --------|<- contact data -----------------|
+        |                          |                                  |
+        |-- POST /member/portal --->| validate token                  |
+        |   (updated fields)       |-- Contact.create (update) ------>|
+        |                          |   Address.create, Phone.create   |
+        |<- success page -----------|                                  |
+
 =head2 Configuration
 
 Two private files are required (following the same pattern as other secrets

--- a/lib/bacds/Scheduler/CiviCRM.pm
+++ b/lib/bacds/Scheduler/CiviCRM.pm
@@ -1,0 +1,325 @@
+=head1 NAME
+
+bacds::Scheduler::CiviCRM - Client for the CiviCRM REST API
+
+=head1 SYNOPSIS
+
+    my $civi = bacds::Scheduler::CiviCRM->new;
+
+    my $contact_ids = $civi->find_contacts_by_email('member@example.com');
+    my $contact     = $civi->get_contact($contact_id);
+    $civi->update_contact($contact_id, \%new_data);
+    $civi->send_magic_link_email($contact_id, $url);
+
+=head1 DESCRIPTION
+
+Wraps CiviCRM's REST API for the member self-service portal.
+
+Data operations use APIv4 (POST /civicrm/ajax/api4/{Entity}/{Action}).
+
+Email sending uses APIv3 MessageTemplate.send (POST /civicrm/ajax/rest),
+which is not available in APIv4.
+
+=head2 Configuration
+
+Two private files are required (following the same pattern as other secrets
+in this app):
+
+  Production: /var/www/bacds.org/dance-scheduler/private/civicrm-api-key
+  Dev:        ~/.civicrm-api-key
+
+  Production: /var/www/bacds.org/dance-scheduler/private/civicrm-magic-link-template-id
+  Dev:        ~/.civicrm-magic-link-template-id
+
+Each file contains a single value on one line. The template ID is the numeric
+ID of the CiviCRM message template used to send the magic link email. The
+template should include a {$selfservice_url} Smarty variable for the link.
+
+=cut
+
+package bacds::Scheduler::CiviCRM;
+
+use 5.16.0;
+use warnings;
+
+use Carp qw/croak/;
+use JSON::MaybeXS qw/encode_json decode_json/;
+use LWP::UserAgent;
+use HTTP::Request::Common;
+
+use constant CIVICRM_BASE_URL => 'https://bacds.civicrm.org';
+
+sub new {
+    my ($class) = @_;
+    my $self = bless {}, $class;
+    $self->{api_key}     = _read_private_file('civicrm-api-key');
+    $self->{template_id} = _read_private_file('civicrm-magic-link-template-id');
+    $self->{ua}          = LWP::UserAgent->new(timeout => 15);
+    return $self;
+}
+
+=head2 find_contacts_by_email($email)
+
+Returns an arrayref of CiviCRM contact_ids (sorted ascending by id) for
+non-deleted, non-deceased contacts that have the given email address.
+Returns an empty arrayref if none found.
+
+=cut
+
+sub find_contacts_by_email {
+    my ($self, $email) = @_;
+
+    my $result = $self->_call_v4('Email', 'get', {
+        select  => ['contact_id'],
+        where   => [
+            ['email',                  '=', $email],
+            ['contact_id.is_deleted',  '=', \0],
+            ['contact_id.is_deceased', '=', \0],
+        ],
+        orderBy => [['contact_id', 'ASC']],
+    });
+
+    return [map { $_->{contact_id} } @{ $result->{values} }];
+}
+
+=head2 get_contact($contact_id)
+
+Returns a hashref with the contact's name, email (read-only), primary
+address, and primary phone. Missing fields default to ''.
+
+=cut
+
+sub get_contact {
+    my ($self, $contact_id) = @_;
+
+    my $contact_result = $self->_call_v4('Contact', 'get', {
+        select => [qw(
+            first_name
+            middle_name
+            last_name
+            nick_name
+            email_primary.email
+        )],
+        where => [['id', '=', $contact_id]],
+    });
+
+    my $contact = $contact_result->{values}[0]
+        or croak "Contact $contact_id not found in CiviCRM";
+
+    my $addr_result = $self->_call_v4('Address', 'get', {
+        select => [qw(
+            id
+            street_address
+            city
+            state_province_id:label
+            postal_code
+            country_id:label
+        )],
+        where  => [
+            ['contact_id', '=', $contact_id],
+            ['is_primary',  '=', \1],
+        ],
+        limit => 1,
+    });
+
+    my $phone_result = $self->_call_v4('Phone', 'get', {
+        select => [qw(id phone)],
+        where  => [
+            ['contact_id', '=', $contact_id],
+            ['is_primary',  '=', \1],
+        ],
+        limit => 1,
+    });
+
+    my $addr  = $addr_result->{values}[0]  // {};
+    my $phone = $phone_result->{values}[0] // {};
+
+    return {
+        contact_id     => $contact_id,
+        first_name     => $contact->{first_name}              // '',
+        middle_name    => $contact->{middle_name}             // '',
+        last_name      => $contact->{last_name}               // '',
+        nick_name      => $contact->{nick_name}               // '',
+        email          => $contact->{'email_primary.email'}   // '',
+        street_address => $addr->{street_address}             // '',
+        city           => $addr->{city}                       // '',
+        state          => $addr->{'state_province_id:label'}  // '',
+        postal_code    => $addr->{postal_code}                // '',
+        country        => $addr->{'country_id:label'}         // 'United States',
+        phone          => $phone->{phone}                     // '',
+    };
+}
+
+=head2 update_contact($contact_id, \%data)
+
+Updates the contact's name fields, primary address, and primary phone in
+CiviCRM. Email is intentionally excluded (read-only). Each section is only
+updated if its keys are present in %data.
+
+=cut
+
+sub update_contact {
+    my ($self, $contact_id, $data) = @_;
+
+    # Update core name fields
+    my %name_fields;
+    for my $field (qw(first_name middle_name last_name nick_name)) {
+        $name_fields{$field} = $data->{$field} if exists $data->{$field};
+    }
+    if (%name_fields) {
+        $self->_call_v4('Contact', 'update', {
+            values => \%name_fields,
+            where  => [['id', '=', $contact_id]],
+        });
+    }
+
+    # Upsert primary address
+    my %addr_fields;
+    for my $field (qw(street_address city postal_code)) {
+        $addr_fields{$field} = $data->{$field} if exists $data->{$field};
+    }
+    $addr_fields{'state_province_id:label'} = $data->{state}   if exists $data->{state};
+    $addr_fields{'country_id:label'}         = $data->{country} if exists $data->{country};
+
+    if (%addr_fields) {
+        my $existing_addr = $self->_call_v4('Address', 'get', {
+            select => ['id'],
+            where  => [
+                ['contact_id', '=', $contact_id],
+                ['is_primary',  '=', \1],
+            ],
+            limit => 1,
+        });
+
+        if (my $addr = $existing_addr->{values}[0]) {
+            $self->_call_v4('Address', 'update', {
+                values => \%addr_fields,
+                where  => [['id', '=', $addr->{id}]],
+            });
+        } else {
+            $self->_call_v4('Address', 'create', {
+                values => {
+                    %addr_fields,
+                    contact_id       => $contact_id,
+                    is_primary       => \1,
+                    location_type_id => 1,  # "Home"
+                },
+            });
+        }
+    }
+
+    # Upsert primary phone
+    if (exists $data->{phone} && $data->{phone} ne '') {
+        my $existing_phone = $self->_call_v4('Phone', 'get', {
+            select => ['id'],
+            where  => [
+                ['contact_id', '=', $contact_id],
+                ['is_primary',  '=', \1],
+            ],
+            limit => 1,
+        });
+
+        if (my $phone = $existing_phone->{values}[0]) {
+            $self->_call_v4('Phone', 'update', {
+                values => { phone => $data->{phone} },
+                where  => [['id', '=', $phone->{id}]],
+            });
+        } else {
+            $self->_call_v4('Phone', 'create', {
+                values => {
+                    contact_id       => $contact_id,
+                    phone            => $data->{phone},
+                    is_primary       => \1,
+                    location_type_id => 1,  # "Home"
+                },
+            });
+        }
+    }
+}
+
+=head2 send_magic_link_email($contact_id, $url)
+
+Sends the magic link email to the contact via CiviCRM's MessageTemplate.send
+(APIv3). The template (configured via civicrm-magic-link-template-id) must
+contain a {$selfservice_url} Smarty variable.
+
+=cut
+
+sub send_magic_link_email {
+    my ($self, $contact_id, $url) = @_;
+
+    $self->_call_v3('MessageTemplate', 'send', {
+        id         => $self->{template_id},
+        contact_id => $contact_id,
+        tplParams  => { selfservice_url => $url },
+    });
+}
+
+# --- private helpers ---
+
+sub _call_v4 {
+    my ($self, $entity, $action, $params) = @_;
+
+    my $url = CIVICRM_BASE_URL . "/civicrm/ajax/api4/$entity/$action";
+    my $req = POST($url,
+        'X-Civi-Auth' => 'Bearer ' . $self->{api_key},
+        Content_Type  => 'application/json',
+        Content       => encode_json($params),
+    );
+
+    return $self->_dispatch($req);
+}
+
+# MessageTemplate.send is only available in APIv3.
+sub _call_v3 {
+    my ($self, $entity, $action, $params) = @_;
+
+    my $url  = CIVICRM_BASE_URL . '/civicrm/ajax/rest';
+    my $body = encode_json({ entity => $entity, action => $action, %$params });
+    my $req  = POST($url,
+        'X-Civi-Auth' => 'Bearer ' . $self->{api_key},
+        Content_Type  => 'application/x-www-form-urlencoded',
+        Content       => [json => $body],
+    );
+
+    return $self->_dispatch($req);
+}
+
+sub _dispatch {
+    my ($self, $req) = @_;
+
+    my $response = $self->{ua}->request($req);
+
+    croak "CiviCRM HTTP error: " . $response->status_line
+        unless $response->is_success;
+
+    my $data = eval { decode_json($response->decoded_content) };
+    croak "CiviCRM returned invalid JSON: $@" if $@;
+
+    if ($data->{is_error}) {
+        croak "CiviCRM API error: " . ($data->{error_message} // 'unknown error');
+    }
+
+    return $data;
+}
+
+sub _read_private_file {
+    my ($filename) = @_;
+
+    my @candidates = (
+        (defined $ENV{HOME} ? "$ENV{HOME}/.$filename" : ()),
+        "/var/www/bacds.org/dance-scheduler/private/$filename",
+    );
+
+    for my $path (@candidates) {
+        next unless -e $path;
+        open my $fh, '<', $path or croak "can't read $path: $!";
+        my $value = <$fh>;
+        chomp $value;
+        return $value;
+    }
+
+    croak "Can't find private file '$filename'; tried: " . join(', ', @candidates);
+}
+
+1;

--- a/lib/bacds/Scheduler/Model/MemberPortal.pm
+++ b/lib/bacds/Scheduler/Model/MemberPortal.pm
@@ -1,0 +1,152 @@
+=head1 NAME
+
+bacds::Scheduler::Model::MemberPortal - Self-service member portal logic
+
+=head1 SYNOPSIS
+
+    use bacds::Scheduler::Model::MemberPortal;
+
+    # Phase 1: trigger a magic link email
+    bacds::Scheduler::Model::MemberPortal->request_link($email, $dbh, $base_url);
+
+    # Phase 2: validate the token and fetch contact data
+    my $contact = bacds::Scheduler::Model::MemberPortal->get_contact_for_portal($token, $dbh);
+
+    # Phase 2: save updated contact data and consume the token
+    bacds::Scheduler::Model::MemberPortal->save_contact($token, \%form_data, $dbh);
+
+=head1 DESCRIPTION
+
+Implements the passwordless self-service flow:
+
+  1. Member enters email address.
+  2. If a matching CiviCRM contact is found, a one-time token is stored in
+     the local database and a magic link email is sent via CiviCRM.
+  3. Member clicks the link, which contains the token in the query string.
+  4. The token is validated (exists, not expired, not used) and the
+     contact's CiviCRM data is fetched and shown in a form.
+  5. Member submits edits, the token is marked used, and CiviCRM is updated.
+
+If multiple contacts share the email address, the one with the lowest
+contact_id is used (same behaviour as de.systopia.selfservice). If no
+contact is found, the call is silently ignored to prevent email enumeration.
+
+Tokens expire after one hour.
+
+=cut
+
+package bacds::Scheduler::Model::MemberPortal;
+
+use 5.16.0;
+use warnings;
+
+use Carp qw/croak/;
+use DateTime;
+
+use bacds::Scheduler::CiviCRM;
+
+use constant TOKEN_TTL_SECONDS => 3600;  # 1 hour
+
+=head2 request_link($email, $dbh, $base_url)
+
+Looks up $email in CiviCRM. If a contact is found, generates a token,
+stores it in the database, and triggers CiviCRM to send the magic link
+email. If no contact is found, does nothing (silent ignore).
+
+$base_url should be the scheme+host of dance-scheduler, e.g.
+'https://bacds.org/dance-scheduler', used to build the portal link.
+
+=cut
+
+sub request_link {
+    my ($class, $email, $dbh, $base_url) = @_;
+
+    my $civi = bacds::Scheduler::CiviCRM->new;
+
+    my $contact_ids = $civi->find_contacts_by_email($email);
+    return unless @$contact_ids;  # silent ignore for unknown emails
+
+    # Use the contact with the lowest id (first in the sorted list)
+    my $contact_id = $contact_ids->[0];
+
+    my $token = _generate_token();
+    my $now   = DateTime->now;
+
+    $dbh->resultset('MemberToken')->create({
+        token              => $token,
+        civicrm_contact_id => $contact_id,
+        created_ts         => $now,
+        expires_ts         => $now->clone->add(seconds => TOKEN_TTL_SECONDS),
+    });
+
+    my $portal_url = "$base_url/member/portal?token=$token";
+    $civi->send_magic_link_email($contact_id, $portal_url);
+}
+
+=head2 get_contact_for_portal($token, $dbh)
+
+Validates the token and returns the contact's data from CiviCRM as a
+hashref (see bacds::Scheduler::CiviCRM->get_contact for the fields).
+
+Dies with a human-readable message if the token is invalid, expired, or
+already used, so routes can pass the message directly to templates.
+
+=cut
+
+sub get_contact_for_portal {
+    my ($class, $token, $dbh) = @_;
+
+    my $token_row = _validate_token($token, $dbh);
+
+    my $civi = bacds::Scheduler::CiviCRM->new;
+    return $civi->get_contact($token_row->civicrm_contact_id);
+}
+
+=head2 save_contact($token, \%form_data, $dbh)
+
+Re-validates the token, updates CiviCRM with the submitted form data, then
+marks the token as used so it cannot be replayed. Dies with a
+human-readable message on token or CiviCRM errors.
+
+=cut
+
+sub save_contact {
+    my ($class, $token, $form_data, $dbh) = @_;
+
+    my $token_row = _validate_token($token, $dbh);
+
+    my $civi = bacds::Scheduler::CiviCRM->new;
+    $civi->update_contact($token_row->civicrm_contact_id, $form_data);
+
+    $token_row->update({ used_ts => DateTime->now });
+}
+
+# --- private helpers ---
+
+sub _validate_token {
+    my ($token, $dbh) = @_;
+
+    # Avoid a DB lookup for obvious junk (tokens are always 64 hex chars)
+    croak "Invalid link." unless $token && $token =~ /\A[0-9a-f]{64}\z/;
+
+    my $row = $dbh->resultset('MemberToken')->find({ token => $token })
+        or croak "This link is not valid.";
+
+    croak "This link has already been used. Please request a new one."
+        if $row->used_ts;
+
+    croak "This link has expired. Please request a new one."
+        if DateTime->compare(DateTime->now, $row->expires_ts) > 0;
+
+    return $row;
+}
+
+sub _generate_token {
+    open my $fh, '<:raw', '/dev/urandom'
+        or croak "can't open /dev/urandom: $!";
+    read $fh, my $bytes, 32;
+    close $fh;
+    return unpack 'H*', $bytes;  # 64 hex chars
+}
+
+1;

--- a/lib/bacds/Scheduler/Model/MemberPortal.pm
+++ b/lib/bacds/Scheduler/Model/MemberPortal.pm
@@ -79,7 +79,7 @@ sub request_link {
         expires_ts         => $now->clone->add(seconds => TOKEN_TTL_SECONDS),
     });
 
-    my $portal_url = "$base_url/member/portal?token=$token";
+    my $portal_url = "$base_url/unearth/member/portal?token=$token";
     $civi->send_magic_link_email($contact_id, $portal_url);
 }
 

--- a/lib/bacds/Scheduler/Schema/Result/MemberToken.pm
+++ b/lib/bacds/Scheduler/Schema/Result/MemberToken.pm
@@ -1,0 +1,32 @@
+use utf8;
+package bacds::Scheduler::Schema::Result::MemberToken;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->load_components("InflateColumn::DateTime");
+
+__PACKAGE__->table("member_tokens");
+
+__PACKAGE__->add_columns(
+    "token_id",
+    { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+    "token",
+    { data_type => "varchar", is_nullable => 0, size => 64 },
+    "civicrm_contact_id",
+    { data_type => "integer", is_nullable => 0 },
+    "created_ts",
+    { data_type => "datetime", datetime_undef_if_invalid => 1, is_nullable => 0 },
+    "expires_ts",
+    { data_type => "datetime", datetime_undef_if_invalid => 1, is_nullable => 0 },
+    "used_ts",
+    { data_type => "datetime", datetime_undef_if_invalid => 1, is_nullable => 1 },
+);
+
+__PACKAGE__->set_primary_key("token_id");
+
+__PACKAGE__->add_unique_constraint("member_token_idx", ["token"]);
+
+1;

--- a/schemas/member_tokens.sql
+++ b/schemas/member_tokens.sql
@@ -1,0 +1,10 @@
+CREATE TABLE member_tokens (
+    token_id           INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    token              VARCHAR(64) NOT NULL,
+    civicrm_contact_id INT NOT NULL,
+    created_ts         DATETIME NOT NULL,
+    expires_ts         DATETIME NOT NULL,
+    used_ts            DATETIME,
+
+    UNIQUE INDEX member_token_idx(token)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/t/530-member-portal.t
+++ b/t/530-member-portal.t
@@ -1,0 +1,288 @@
+
+# Tests for the member self-service portal:
+#   bacds::Scheduler::Model::MemberPortal
+#   GET/POST /unearth/member and /unearth/member/portal
+
+use 5.16.0;
+use warnings;
+
+use DateTime;
+use HTTP::Request::Common;
+use Test::More;
+
+use bacds::Scheduler;
+use bacds::Scheduler::CiviCRM;
+use bacds::Scheduler::Model::MemberPortal;
+use bacds::Scheduler::Util::Db  qw/get_dbh/;
+use bacds::Scheduler::Util::Test qw/setup_test_db get_tester/;
+
+setup_test_db;
+
+my $dbh  = get_dbh();
+my $Test = get_tester();  # no auth needed - portal is public
+
+# --- Mock CiviCRM so tests don't need real API keys or network ---
+#
+# $find_contacts_stub: arrayref of contact_ids to return, or undef for []
+# $get_contact_stub:   hashref to return, or undef for the default fake contact
+# $last_magic_link:    populated whenever send_magic_link_email is called
+# $last_update:        populated whenever update_contact is called
+
+my ($find_contacts_stub, $get_contact_stub, $last_magic_link, $last_update);
+
+{
+    no warnings 'redefine';
+
+    *bacds::Scheduler::CiviCRM::new = sub {
+        bless {}, shift;
+    };
+
+    *bacds::Scheduler::CiviCRM::find_contacts_by_email = sub {
+        my ($self, $email) = @_;
+        return $find_contacts_stub // [];
+    };
+
+    *bacds::Scheduler::CiviCRM::get_contact = sub {
+        my ($self, $contact_id) = @_;
+        return $get_contact_stub // _fake_contact($contact_id);
+    };
+
+    *bacds::Scheduler::CiviCRM::update_contact = sub {
+        my ($self, $contact_id, $data) = @_;
+        $last_update = { contact_id => $contact_id, data => $data };
+    };
+
+    *bacds::Scheduler::CiviCRM::send_magic_link_email = sub {
+        my ($self, $contact_id, $url) = @_;
+        $last_magic_link = { contact_id => $contact_id, url => $url };
+    };
+}
+
+test_get_request_page();
+test_post_request_link_bad_email();
+test_post_request_link_unknown_email();
+test_post_request_link_known_email();
+test_post_request_link_multiple_contacts();
+test_portal_invalid_token();
+test_portal_expired_token();
+test_portal_used_token();
+test_portal_valid_token();
+test_portal_save_success();
+test_portal_save_consumes_token();
+
+done_testing;
+
+# --- test functions ---
+
+sub test_get_request_page {
+    my $res = $Test->request(GET '/unearth/member');
+    ok $res->is_success, 'GET /unearth/member returns 200';
+    like $res->content, qr{Email address}, 'shows email input';
+    like $res->content, qr{Send me a link}, 'shows submit button';
+}
+
+sub test_post_request_link_bad_email {
+    my $res;
+
+    $res = $Test->request(POST '/unearth/member/request-link', { email => '' });
+    ok $res->is_success, 'POST with empty email returns 200';
+    like $res->content, qr{Please enter a valid email address},
+        'shows validation error for empty email';
+
+    $res = $Test->request(POST '/unearth/member/request-link', { email => 'notanemail' });
+    ok $res->is_success, 'POST with no @ returns 200';
+    like $res->content, qr{Please enter a valid email address},
+        'shows validation error for no-@ email';
+}
+
+sub test_post_request_link_unknown_email {
+    $find_contacts_stub = [];
+    $last_magic_link    = undef;
+
+    my $res = $Test->request(POST '/unearth/member/request-link',
+        { email => 'unknown@example.com' });
+
+    ok $res->is_success, 'POST with unknown email returns 200';
+    like $res->content, qr{Check Your Email}, 'shows confirmation page';
+    ok !$last_magic_link, 'no email sent for unknown address (silent ignore)';
+}
+
+sub test_post_request_link_known_email {
+    $find_contacts_stub = [42];
+    $last_magic_link    = undef;
+
+    my $res = $Test->request(POST '/unearth/member/request-link',
+        { email => 'member@example.com' });
+
+    ok $res->is_success, 'POST with known email returns 200';
+    like $res->content, qr{Check Your Email}, 'shows confirmation page';
+
+    ok $last_magic_link, 'email was sent';
+    is $last_magic_link->{contact_id}, 42, 'email sent to correct contact';
+    like $last_magic_link->{url}, qr{/unearth/member/portal\?token=[0-9a-f]{64}},
+        'email URL contains valid portal link with token';
+
+    my ($token) = $last_magic_link->{url} =~ /token=([0-9a-f]{64})/;
+    my $row = $dbh->resultset('MemberToken')->find({ token => $token });
+    ok $row,                              'token stored in database';
+    is $row->civicrm_contact_id, 42,     'token linked to correct contact';
+    ok !$row->used_ts,                    'token is not yet used';
+}
+
+sub test_post_request_link_multiple_contacts {
+    # When multiple contacts share the email, the lowest contact_id is used
+    $find_contacts_stub = [7, 99, 150];
+    $last_magic_link    = undef;
+
+    $Test->request(POST '/unearth/member/request-link',
+        { email => 'shared@example.com' });
+
+    ok $last_magic_link, 'email sent for ambiguous address';
+    is $last_magic_link->{contact_id}, 7, 'used the lowest contact_id';
+}
+
+sub test_portal_invalid_token {
+    my $res;
+
+    $res = $Test->request(GET '/unearth/member/portal');
+    ok $res->is_success, 'GET portal without token returns 200';
+    like $res->content, qr{Invalid link}, 'shows error for missing token';
+
+    $res = $Test->request(GET '/unearth/member/portal?token=notahextoken');
+    ok $res->is_success, 'GET portal with non-hex token returns 200';
+    like $res->content, qr{Invalid link}, 'shows error for malformed token';
+
+    my $short_token = 'a' x 32;  # right chars, wrong length
+    $res = $Test->request(GET "/unearth/member/portal?token=$short_token");
+    ok $res->is_success, 'GET portal with short token returns 200';
+    like $res->content, qr{Invalid link}, 'shows error for short token';
+
+    my $unknown_token = 'b' x 64;  # right format, not in DB
+    $res = $Test->request(GET "/unearth/member/portal?token=$unknown_token");
+    ok $res->is_success, 'GET portal with unknown token returns 200';
+    like $res->content, qr{not valid}, 'shows error for unknown token';
+}
+
+sub test_portal_expired_token {
+    my $token = 'c' x 64;
+    $dbh->resultset('MemberToken')->create({
+        token              => $token,
+        civicrm_contact_id => 42,
+        created_ts         => DateTime->now->subtract(hours => 2),
+        expires_ts         => DateTime->now->subtract(hours => 1),
+    });
+
+    my $res = $Test->request(GET "/unearth/member/portal?token=$token");
+    ok $res->is_success, 'GET portal with expired token returns 200';
+    like $res->content, qr{expired}, 'shows expiry error';
+}
+
+sub test_portal_used_token {
+    my $token = 'd' x 64;
+    $dbh->resultset('MemberToken')->create({
+        token              => $token,
+        civicrm_contact_id => 42,
+        created_ts         => DateTime->now,
+        expires_ts         => DateTime->now->add(hours => 1),
+        used_ts            => DateTime->now,
+    });
+
+    my $res = $Test->request(GET "/unearth/member/portal?token=$token");
+    ok $res->is_success, 'GET portal with used token returns 200';
+    like $res->content, qr{already been used}, 'shows already-used error';
+}
+
+sub test_portal_valid_token {
+    my $token = _insert_valid_token(42);
+    $get_contact_stub = _fake_contact(42);
+
+    my $res = $Test->request(GET "/unearth/member/portal?token=$token");
+    ok $res->is_success, 'GET portal with valid token returns 200';
+    like $res->content, qr{Wanda},            'shows contact first name';
+    like $res->content, qr{Tinasky},          'shows contact last name';
+    like $res->content, qr{wanda\@example\.com}, 'shows contact email';
+    unlike $res->content, qr{already been used|expired|not valid|Invalid link},
+        'no error message on valid token';
+}
+
+sub test_portal_save_success {
+    my $token = _insert_valid_token(42);
+    $last_update = undef;
+
+    my $res = $Test->request(POST '/unearth/member/portal', {
+        token          => $token,
+        first_name     => 'Wanda',
+        last_name      => 'Tinasky',
+        middle_name    => '',
+        nick_name      => 'Wand',
+        phone          => '415-555-1234',
+        street_address => '1 Main St',
+        city           => 'Berkeley',
+        state          => 'California',
+        postal_code    => '94701',
+        country        => 'United States',
+    });
+    ok $res->is_success, 'POST portal with valid token returns 200';
+    like $res->content, qr{Changes Saved}, 'shows success page';
+
+    ok $last_update, 'update_contact was called';
+    is $last_update->{contact_id}, 42, 'updated the correct contact';
+    is $last_update->{data}{first_name}, 'Wanda', 'submitted first_name passed through';
+    is $last_update->{data}{phone}, '415-555-1234', 'submitted phone passed through';
+
+    my $row = $dbh->resultset('MemberToken')->find({ token => $token });
+    ok $row->used_ts, 'token is marked used after save';
+}
+
+sub test_portal_save_consumes_token {
+    my $token = _insert_valid_token(42);
+    $get_contact_stub = _fake_contact(42);
+
+    my $params = {
+        token => $token, first_name => 'Wanda', last_name => 'Tinasky',
+        middle_name => '', nick_name => '', phone => '',
+        street_address => '', city => '', state => '', postal_code => '',
+        country => 'United States',
+    };
+
+    my $res = $Test->request(POST '/unearth/member/portal', $params);
+    ok $res->is_success, 'first POST succeeds';
+    like $res->content, qr{Changes Saved}, 'first POST shows success';
+
+    $res = $Test->request(POST '/unearth/member/portal', $params);
+    ok $res->is_success, 'second POST with same token returns 200';
+    like $res->content, qr{already been used},
+        'second POST shows already-used error';
+}
+
+# --- helpers ---
+
+sub _fake_contact {
+    my ($id) = @_;
+    return {
+        contact_id     => $id,
+        first_name     => 'Wanda',
+        middle_name    => '',
+        last_name      => 'Tinasky',
+        nick_name      => '',
+        email          => 'wanda@example.com',
+        phone          => '',
+        street_address => '',
+        city           => '',
+        state          => '',
+        postal_code    => '',
+        country        => 'United States',
+    };
+}
+
+sub _insert_valid_token {
+    my ($contact_id) = @_;
+    my $token = bacds::Scheduler::Model::MemberPortal::_generate_token();
+    $dbh->resultset('MemberToken')->create({
+        token              => $token,
+        civicrm_contact_id => $contact_id,
+        created_ts         => DateTime->now,
+        expires_ts         => DateTime->now->add(hours => 1),
+    });
+    return $token;
+}

--- a/views/layouts/unearth-page-wrapper.tt
+++ b/views/layouts/unearth-page-wrapper.tt
@@ -177,6 +177,9 @@
                     <li class="nav-item dropdown-item"><a href="https://bacds.org/memberform/"
                         class="nav-link">Become a Member</a>
                     </li>
+                    <li class="nav-item dropdown-item"><a href="<% make_link("/unearth/member") %>"
+                        class="nav-link">Update Membership Details</a>
+                    </li>
                     <li class="nav-item dropdown-item"><a href="https://bacds.org/donate/" class="nav-link">Donate</a>
                     </li>
                     <li class="nav-item dropdown-item"><a href="https://bacds.org/covid/" class="nav-link">COVID Safety

--- a/views/member/portal.tt
+++ b/views/member/portal.tt
@@ -1,0 +1,100 @@
+<%# Wrapped by views/layouts/scheduler-page.tt (via unearth-page-wrapper layout) %>
+<div class="body-and-sidebar">
+  <a name="top"></a>
+  <h1 class="text-center">Your BACDS Membership Info</h1>
+
+  <% IF error %>
+    <div class="alert alert-danger text-center" role="alert">
+      <% error | html %>
+      <br>
+      <a href="<% request.uri_base %>/unearth/member">Request a new link</a>
+    </div>
+  <% ELSE %>
+
+  <p class="text-center text-muted">
+    Changes are saved directly to your BACDS membership record.
+    To update your email address, please
+    <a href="/contact/">contact us</a>.
+  </p>
+
+  <form action="<% request.uri_base %>/unearth/member/portal" method="POST" style="max-width: 640px; margin: 0 auto;">
+    <input type="hidden" name="token" value="<% token | html %>">
+
+    <h2>Name</h2>
+    <div class="row mb-2">
+      <div class="col-md-4 mb-2">
+        <label class="form-label" for="first_name">First name</label>
+        <input type="text" class="form-control" id="first_name" name="first_name"
+          value="<% contact.first_name | html %>" autocomplete="given-name">
+      </div>
+      <div class="col-md-3 mb-2">
+        <label class="form-label" for="middle_name">Middle name</label>
+        <input type="text" class="form-control" id="middle_name" name="middle_name"
+          value="<% contact.middle_name | html %>">
+      </div>
+      <div class="col-md-4 mb-2">
+        <label class="form-label" for="last_name">Last name</label>
+        <input type="text" class="form-control" id="last_name" name="last_name"
+          value="<% contact.last_name | html %>" autocomplete="family-name">
+      </div>
+    </div>
+    <div class="row mb-3">
+      <div class="col-md-6 mb-2">
+        <label class="form-label" for="nick_name">Preferred name / nickname</label>
+        <input type="text" class="form-control" id="nick_name" name="nick_name"
+          value="<% contact.nick_name | html %>">
+      </div>
+    </div>
+
+    <h2>Contact</h2>
+    <div class="row mb-2">
+      <div class="col-md-6 mb-2">
+        <label class="form-label" for="email_display">Email (read-only)</label>
+        <input type="email" class="form-control" id="email_display"
+          value="<% contact.email | html %>" disabled>
+      </div>
+      <div class="col-md-6 mb-2">
+        <label class="form-label" for="phone">Phone</label>
+        <input type="tel" class="form-control" id="phone" name="phone"
+          value="<% contact.phone | html %>" autocomplete="tel">
+      </div>
+    </div>
+
+    <h2>Address</h2>
+    <div class="mb-2">
+      <label class="form-label" for="street_address">Street address</label>
+      <input type="text" class="form-control" id="street_address" name="street_address"
+        value="<% contact.street_address | html %>" autocomplete="street-address">
+    </div>
+    <div class="row mb-2">
+      <div class="col-md-5 mb-2">
+        <label class="form-label" for="city">City</label>
+        <input type="text" class="form-control" id="city" name="city"
+          value="<% contact.city | html %>" autocomplete="address-level2">
+      </div>
+      <div class="col-md-3 mb-2">
+        <label class="form-label" for="state">State</label>
+        <input type="text" class="form-control" id="state" name="state"
+          value="<% contact.state | html %>" autocomplete="address-level1"
+          placeholder="e.g. California">
+      </div>
+      <div class="col-md-4 mb-2">
+        <label class="form-label" for="postal_code">ZIP / Postal code</label>
+        <input type="text" class="form-control" id="postal_code" name="postal_code"
+          value="<% contact.postal_code | html %>" autocomplete="postal-code">
+      </div>
+    </div>
+    <div class="row mb-3">
+      <div class="col-md-6 mb-2">
+        <label class="form-label" for="country">Country</label>
+        <input type="text" class="form-control" id="country" name="country"
+          value="<% contact.country | html %>" autocomplete="country-name">
+      </div>
+    </div>
+
+    <div class="text-center">
+      <button type="submit" class="btn btn-primary btn-lg">Save changes</button>
+    </div>
+  </form>
+  <% END %>
+</div>

--- a/views/member/portal_success.tt
+++ b/views/member/portal_success.tt
@@ -1,0 +1,11 @@
+<%# Wrapped by views/layouts/scheduler-page.tt (via unearth-page-wrapper layout) %>
+<div class="body-and-sidebar text-center">
+  <a name="top"></a>
+  <h1>Changes Saved</h1>
+
+  <p>Your BACDS membership information has been updated.</p>
+  <p>
+    If you need to make further changes, please
+    <a href="<% request.uri_base %>/unearth/member">request a new link</a>.
+  </p>
+</div>

--- a/views/member/request.tt
+++ b/views/member/request.tt
@@ -1,0 +1,34 @@
+<%# Wrapped by views/layouts/scheduler-page.tt (via unearth-page-wrapper layout) %>
+<div class="body-and-sidebar text-center">
+  <a name="top"></a>
+  <h1>Manage Your BACDS Membership Info</h1>
+
+  <p>
+    Enter the email address associated with your BACDS membership. We will
+    send you a secure link to view and update your contact information.
+  </p>
+
+  <% IF error %>
+    <div class="alert alert-danger" role="alert">
+      <% error | html %>
+    </div>
+  <% END %>
+
+  <form action="<% request.uri_base %>/unearth/member/request-link" method="POST">
+    <div class="container" style="max-width: 480px; margin: 0 auto;">
+      <div class="mb-3">
+        <label class="form-label" for="email">Email address</label>
+        <input
+          type="email"
+          class="form-control"
+          id="email"
+          name="email"
+          required
+          autocomplete="email"
+          value="<% email | html %>"
+        >
+      </div>
+      <button type="submit" class="btn btn-primary">Send me a link</button>
+    </div>
+  </form>
+</div>

--- a/views/member/request_sent.tt
+++ b/views/member/request_sent.tt
@@ -1,0 +1,15 @@
+<%# Wrapped by views/layouts/scheduler-page.tt (via unearth-page-wrapper layout) %>
+<div class="body-and-sidebar text-center">
+  <a name="top"></a>
+  <h1>Check Your Email</h1>
+
+  <p>
+    If we found a BACDS membership record for that address, we've sent you
+    an email with a link to manage your contact information.
+  </p>
+  <p>
+    The link expires in one hour. If you don't see the email, check your
+    spam folder or
+    <a href="<% request.uri_base %>/unearth/member">try again</a>.
+  </p>
+</div>


### PR DESCRIPTION
Full caution ahead - I've never written perl before so this is all Claude. At this point, just looking for feedback on the overall direction.

Implements a passwordless email-based flow for BACDS members to view and update their own CiviCRM contact information, following the same workflow as the de.systopia.selfservice CiviCRM extension.

New components:
- schemas/member_tokens.sql: one-time token table (1hr TTL)
- lib/bacds/Scheduler/Schema/Result/MemberToken.pm: DBIx::Class ORM class
- lib/bacds/Scheduler/CiviCRM.pm: CiviCRM REST API client (APIv4 for data, APIv3 for MessageTemplate.send)
- lib/bacds/Scheduler/Model/MemberPortal.pm: token lifecycle + CiviCRM logic
- 4 new routes in Scheduler.pm at /unearth/member and /unearth/member/portal
- views/member/: request, request_sent, portal, portal_success templates
- "Update Membership Details" link in About Us > For Dancers nav dropdown

Two manual steps are still needed before this can run:
- Apply schemas/member_tokens.sql to the database
- Create two private config files (civicrm-api-key, civicrm-magic-link-template-id) and the corresponding CiviCRM API key and message template. We'll need to get them to enable the API, and possibly the 'API Key' extension.