### PR TITLE
Member portal

### DIFF
--- a/lib/bacds/Scheduler/CiviCRM.pm
+++ b/lib/bacds/Scheduler/CiviCRM.pm
@@ -115,6 +115,7 @@ use warnings;
 
 use Carp qw/croak/;
 use Data::Dump qw/dump/;
+use DateTime;
 use JSON::MaybeXS qw/encode_json decode_json/;
 use LWP::UserAgent;
 use HTTP::Request::Common;
@@ -232,22 +233,40 @@ sub get_contact {
         limit => 1,
     });
 
-    my $addr  = $addr_result->{values}[0]  // {};
-    my $phone = $phone_result->{values}[0] // {};
+    my $membership_result = $self->_call_v4('Membership', 'get', {
+        select  => [qw(
+            end_date
+            membership_type_id:name
+        )],
+        where   => [['contact_id', '=', $contact_id]],
+        orderBy => {'end_date' => 'DESC'},
+        limit   => 1,
+    });
+
+    my $addr       = $addr_result->{values}[0]       // {};
+    my $phone      = $phone_result->{values}[0]      // {};
+    my $membership = $membership_result->{values}[0] // {};
 
     return {
-        contact_id     => $contact_id,
-        first_name     => $contact->{first_name}              // '',
-        middle_name    => $contact->{middle_name}             // '',
-        last_name      => $contact->{last_name}               // '',
-        nick_name      => $contact->{nick_name}               // '',
-        email          => $contact->{'email_primary.email'}   // '',
-        street_address => $addr->{street_address}             // '',
-        city           => $addr->{city}                       // '',
-        state          => $addr->{'state_province_id:label'}  // '',
-        postal_code    => $addr->{postal_code}                // '',
-        country        => $addr->{'country_id:label'}         // 'United States',
-        phone          => $phone->{phone}                     // '',
+        contact_id           => $contact_id,
+        first_name           => $contact->{first_name} // '',
+        middle_name          => $contact->{middle_name} // '',
+        last_name            => $contact->{last_name} // '',
+        nick_name            => $contact->{nick_name} // '',
+        email                => $contact->{'email_primary.email'} // '',
+        street_address       => $addr->{street_address} // '',
+        city                 => $addr->{city} // '',
+        state                => $addr->{'state_province_id:label'} // '',
+        postal_code          => $addr->{postal_code} // '',
+        country              => $addr->{'country_id:label'} // 'United States',
+        phone                => $phone->{phone} // '',
+        membership_type_name => $membership->{'membership_type_id:name'} // '',
+        membership_end       => $membership->{end_date} // '',
+        membership_is_active => (
+            $membership->{end_date}
+                ? (DateTime->now->ymd le $membership->{end_date} ? 1 : 0)
+                : undef
+        ),
     };
 }
 

--- a/lib/bacds/Scheduler/CiviCRM.pm
+++ b/lib/bacds/Scheduler/CiviCRM.pm
@@ -6,7 +6,7 @@ bacds::Scheduler::CiviCRM - Client for the CiviCRM REST API
 
     my $civi = bacds::Scheduler::CiviCRM->new;
 
-    my $contact = $civi->find_contacts_by_email('member@example.com');
+    my $contact = $civi->find_member_contacts_by_email('member@example.com');
     my $contact_id = $contacts->[0]{contact_id}
     my $contact    = $civi->get_contact($contact_id);
     $civi->update_contact($contact_id, \%new_data);
@@ -143,7 +143,7 @@ sub new {
     return $self;
 }
 
-=head2 find_contacts_by_email($email)
+=head2 find_member_contacts_by_email($email)
 
 Returns an arrayref of CiviCRM contact hashes:
 
@@ -153,35 +153,40 @@ Returns an arrayref of CiviCRM contact hashes:
     }
 
 (sorted ascending by id) for non-deleted, non-deceased contacts that have the
-given email address.
+given email address AND have at least one membership record.
+
+CiviCRM may also hold contacts who have never been members — e.g. people who
+registered for an event or made a one-off payment. Those contacts are excluded
+here because the member portal is specifically for reviewing and updating
+membership information, and showing it to non-members would be confusing.
 
 Returns an empty arrayref if none found.
 
 =cut
 
-sub find_contacts_by_email {
+sub find_member_contacts_by_email {
     my ($self, $email) = @_;
 
     my $result = $self->_call_v4('Email', 'get', {
         select  => ['contact_id', 'contact_id.display_name'],
+        join    => [['Membership AS membership', 'INNER', ['contact_id', '=', 'membership.contact_id']]],
         where   => [
             ['email',                  '=', $email],
             ['contact_id.is_deleted',  '=', \0],
             ['contact_id.is_deceased', '=', \0],
-            # JSON::MaybeXS->false?
         ],
-        orderBy => {'contact_id', 'ASC'},
-        #debug => JSON::MaybeXS->true,
+        groupBy => ['contact_id'],
+        orderBy => {'contact_id' => 'ASC'},
     });
 
     return [
         map {
             {
-                contact_id => $_->{contact_id},
+                contact_id   => $_->{contact_id},
                 display_name => $_->{'contact_id.display_name'},
             }
         } @{ $result->{values} }
-     ];
+    ];
 }
 
 =head2 get_contact($contact_id)

--- a/lib/bacds/Scheduler/Model/MemberPortal.pm
+++ b/lib/bacds/Scheduler/Model/MemberPortal.pm
@@ -63,7 +63,7 @@ sub request_link {
 
     my $civi = bacds::Scheduler::CiviCRM->new;
 
-    my $contacts = $civi->find_contacts_by_email($email);
+    my $contacts = $civi->find_member_contacts_by_email($email);
     #return unless @$contacts;  # silent ignore for unknown emails
     if (!@$contacts) {
         warn "civicrm request_link: no contacts found for $email";
@@ -104,7 +104,12 @@ sub get_contact_for_portal {
     my $token_row = _validate_token($token, $dbh);
 
     my $civi = bacds::Scheduler::CiviCRM->new;
-    return $civi->get_contact($token_row->civicrm_contact_id);
+    my $contact = $civi->get_contact($token_row->civicrm_contact_id);
+
+    croak "No membership record found for this account.\n"
+        unless defined $contact->{membership_is_active};
+
+    return $contact;
 }
 
 =head2 save_contact($token, \%form_data, $dbh)

--- a/public/css/unearth/bacds.css
+++ b/public/css/unearth/bacds.css
@@ -196,3 +196,10 @@ a.quieter-link:hover {
   text-decoration:none;
   margin-top:6px;"
 }
+
+/* Member portal: visually distinguish read-only fields from editable ones.
+ * !important needed because style.css sets .form-control { background: #fff !important } */
+.member-portal .form-control:disabled {
+  background-color: #e9ecef !important;
+  opacity: 1; /* override Bootstrap's 0.65 opacity on disabled inputs */
+}

--- a/t/530-member-portal.t
+++ b/t/530-member-portal.t
@@ -38,7 +38,7 @@ my ($find_contacts_stub, $get_contact_stub, $last_magic_link, $last_update);
         bless {}, shift;
     };
 
-    *bacds::Scheduler::CiviCRM::find_contacts_by_email = sub {
+    *bacds::Scheduler::CiviCRM::find_member_contacts_by_email = sub {
         my ($self, $email) = @_;
         return $find_contacts_stub // [];
     };
@@ -62,6 +62,7 @@ my ($find_contacts_stub, $get_contact_stub, $last_magic_link, $last_update);
 test_get_request_page();
 test_post_request_link_bad_email();
 test_post_request_link_unknown_email();
+test_post_request_link_non_member_email();
 test_post_request_link_known_email();
 test_post_request_link_multiple_contacts();
 test_portal_invalid_token();
@@ -114,6 +115,25 @@ sub test_post_request_link_unknown_email {
     ok $res->is_success, 'POST with unknown email returns 200';
     like $res->content, qr{Check Your Email}, 'shows confirmation page';
     ok !$last_magic_link, 'no email sent for unknown address (silent ignore)';
+}
+
+sub test_post_request_link_non_member_email {
+    # Email is known in CiviCRM but the contact has no membership record;
+    # find_member_contacts_by_email returns [] just like an unknown email.
+    $find_contacts_stub = [];
+    $last_magic_link    = undef;
+
+    my $res;
+    warning_like {
+        $res = $Test->request(POST '/unearth/member/request-link',
+            { email => 'nonmember@example.com' }
+        );
+    } qr{^civicrm request_link: no contacts found for nonmember\@example.com},
+    'got expected warning for non-member email';
+
+    ok $res->is_success, 'POST with non-member email returns 200';
+    like $res->content, qr{Check Your Email}, 'shows same confirmation page as unknown email';
+    ok !$last_magic_link, 'no email sent for non-member address';
 }
 
 sub test_post_request_link_known_email {
@@ -233,8 +253,10 @@ sub test_portal_valid_token_no_membership {
 
     my $res = $Test->request(GET "/unearth/member/portal?token=$token");
     ok $res->is_success, 'GET portal with no membership returns 200';
-    unlike $res->content, qr{input-group-text text-success|input-group-text text-danger},
-        'no status icon shown when membership is absent';
+    like $res->content, qr{No membership record found},
+        'shows error for contact with no membership history';
+    unlike $res->content, qr{Save changes},
+        'does not show the edit form for non-members';
 }
 
 sub test_portal_valid_token_expired_membership {

--- a/t/530-member-portal.t
+++ b/t/530-member-portal.t
@@ -68,6 +68,8 @@ test_portal_invalid_token();
 test_portal_expired_token();
 test_portal_used_token();
 test_portal_valid_token();
+test_portal_valid_token_no_membership();
+test_portal_valid_token_expired_membership();
 test_portal_save_success();
 test_portal_save_consumes_token();
 
@@ -210,11 +212,44 @@ sub test_portal_valid_token {
 
     my $res = $Test->request(GET "/unearth/member/portal?token=$token");
     ok $res->is_success, 'GET portal with valid token returns 200';
-    like $res->content, qr{Wanda},            'shows contact first name';
-    like $res->content, qr{Tinasky},          'shows contact last name';
+    like $res->content, qr{Wanda},               'shows contact first name';
+    like $res->content, qr{Tinasky},             'shows contact last name';
     like $res->content, qr{wanda\@example\.com}, 'shows contact email';
+    like $res->content, qr{Regular},             'shows membership type';
+    like $res->content, qr{2026-12-31},          'shows membership expiry';
+    like $res->content, qr{input-group-text text-success}, 'shows green check for current membership';
     unlike $res->content, qr{already been used|expired|not valid|Invalid link},
         'no error message on valid token';
+}
+
+sub test_portal_valid_token_no_membership {
+    my $token = _insert_valid_token(42);
+    $get_contact_stub = {
+        _fake_contact(42)->%*,
+        membership_type_name => '',
+        membership_end       => '',
+        membership_is_active => undef,
+    };
+
+    my $res = $Test->request(GET "/unearth/member/portal?token=$token");
+    ok $res->is_success, 'GET portal with no membership returns 200';
+    unlike $res->content, qr{input-group-text text-success|input-group-text text-danger},
+        'no status icon shown when membership is absent';
+}
+
+sub test_portal_valid_token_expired_membership {
+    my $token = _insert_valid_token(42);
+    $get_contact_stub = {
+        _fake_contact(42)->%*,
+        membership_type_name => 'Regular',
+        membership_end       => '2020-01-01',
+        membership_is_active => 0,
+    };
+
+    my $res = $Test->request(GET "/unearth/member/portal?token=$token");
+    ok $res->is_success, 'GET portal with expired membership returns 200';
+    like $res->content, qr{input-group-text text-danger},   'shows red X for lapsed membership';
+    unlike $res->content, qr{input-group-text text-success}, 'does not show green check';
 }
 
 sub test_portal_save_success {
@@ -272,18 +307,21 @@ sub test_portal_save_consumes_token {
 sub _fake_contact {
     my ($id) = @_;
     return {
-        contact_id     => $id,
-        first_name     => 'Wanda',
-        middle_name    => '',
-        last_name      => 'Tinasky',
-        nick_name      => '',
-        email          => 'wanda@example.com',
-        phone          => '',
-        street_address => '',
-        city           => '',
-        state          => '',
-        postal_code    => '',
-        country        => 'United States',
+        contact_id           => $id,
+        first_name           => 'Wanda',
+        middle_name          => '',
+        last_name            => 'Tinasky',
+        nick_name            => '',
+        email                => 'wanda@example.com',
+        phone                => '',
+        street_address       => '',
+        city                 => '',
+        state                => '',
+        postal_code          => '',
+        country              => 'United States',
+        membership_type_name => 'Regular',
+        membership_end       => '2026-12-31',
+        membership_is_active => 1,
     };
 }
 

--- a/views/member/portal.tt
+++ b/views/member/portal.tt
@@ -1,6 +1,7 @@
 <%# Wrapped by views/layouts/scheduler-page.tt (via unearth-page-wrapper layout) %>
 <div class="body-and-sidebar">
   <a name="top"></a>
+  <div style="max-width: 640px; margin: 0 auto;">
   <h1 class="text-center">Your BACDS Membership Info</h1>
 
   <% IF error %>
@@ -19,7 +20,7 @@
     <a href="/contact/">contact us</a>.
   </p>
 
-  <form action="<% request.uri_base %>/unearth/member/portal" method="POST" style="max-width: 640px; margin: 0 auto;">
+  <form class="member-portal" action="<% request.uri_base %>/unearth/member/portal" method="POST">
     <input type="hidden" name="token" value="<% token | html %>">
 
     <h2>Name</h2>
@@ -120,4 +121,5 @@
     </div>
   </form>
   <% END %>
+  </div>
 </div>

--- a/views/member/portal.tt
+++ b/views/member/portal.tt
@@ -12,7 +12,8 @@
   <% ELSE %>
 
   <p class="text-center text-muted">
-    Changes are saved directly to your BACDS membership record.
+    You can update your name, contact, and address information below.
+    Membership status is shown for reference and cannot be changed here.
     To update your email address, please
 <!-- FIXME TODO there is no /contact/ url -->
     <a href="/contact/">contact us</a>.
@@ -44,6 +45,27 @@
         <label class="form-label" for="nick_name">Preferred name / nickname</label>
         <input type="text" class="form-control" id="nick_name" name="nick_name"
           value="<% contact.nick_name | html %>">
+      </div>
+    </div>
+
+    <h2>Membership <small class="text-muted fs-6 fw-normal">(read-only)</small></h2>
+    <div class="row mb-3">
+      <div class="col-md-6 mb-2">
+        <label class="form-label">Membership type</label>
+        <input type="text" class="form-control" value="<% contact.membership_type_name | html %>" disabled>
+      </div>
+      <div class="col-md-4 mb-2">
+        <label class="form-label">Membership expires</label>
+        <div class="input-group">
+          <input type="text" class="form-control" value="<% contact.membership_end | html %>" disabled>
+          <% IF contact.membership_is_active.defined %>
+            <% IF contact.membership_is_active %>
+              <span class="input-group-text text-success">&#10003;</span>
+            <% ELSE %>
+              <span class="input-group-text text-danger">&#10007;</span>
+            <% END %>
+          <% END %>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Display read-only information about a user's membership in the portal

Ensure that we only generate links for members, excluding other contacts we might have in CiviCRM.
Fetch membership type and expiry from the Membership and MembershipType tables.
Display membership information on the portal, and add a note that it is read only.
Update CSS to make disabled fields distinct from those the user can edit, and fix an issue with the width of some text in the membership portal.

Example with an expired membership on mobile:
<img width="1179" height="1866" alt="IMG_8200" src="https://github.com/user-attachments/assets/cf8eb1cd-880a-482f-a7ed-450f47f85822" />
